### PR TITLE
Fix typo in Parasitics logging helper

### DIFF
--- a/app/src/main/java/moe/ono/lifecycle/Parasitics.java
+++ b/app/src/main/java/moe/ono/lifecycle/Parasitics.java
@@ -123,7 +123,7 @@ public class Parasitics {
                 loader.addProvider(provider);
                 ResourcesLoaderHolderApi30.sResourcesLoader = loader;
             } catch (IOException e) {
-                logForResourceInjectFaulure(path, e, 0);
+                logForResourceInjectFailure(path, e, 0);
                 return;
             }
         }
@@ -147,7 +147,7 @@ public class Parasitics {
                     sResInjectEndTime = System.currentTimeMillis();
                 }
             } catch (Resources.NotFoundException e) {
-                logForResourceInjectFaulure(path, e, 0);
+                logForResourceInjectFailure(path, e, 0);
             }
         });
     }
@@ -166,14 +166,14 @@ public class Parasitics {
                     sResInjectEndTime = System.currentTimeMillis();
                 }
             } catch (Resources.NotFoundException e) {
-                logForResourceInjectFaulure(path, e, 0);
+                logForResourceInjectFailure(path, e, 0);
             }
         } catch (Exception e) {
             Logger.e(e);
         }
     }
 
-    private static void logForResourceInjectFaulure(@NonNull String path, @NonNull Throwable e, int cookie) {
+    private static void logForResourceInjectFailure(@NonNull String path, @NonNull Throwable e, int cookie) {
         Logger.e("Fatal: injectModuleResources: test injection failure!");
         Logger.e("injectModuleResources: path=" + path + ", cookie=" + cookie +
                 ", loader=" + ModernHookEntry.class.getClassLoader());


### PR DESCRIPTION
## Summary
- correct `logForResourceInjectFaulure` typo in `Parasitics`
- update all usages to new `logForResourceInjectFailure` method

## Testing
- `./gradlew test --no-daemon` *(fails: NoRouteToHostException)*

------
https://chatgpt.com/codex/tasks/task_b_683a31b8b5c88332a14e541bbb061e24