### PR TITLE
Enable build on PR

### DIFF
--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{!startsWith(github.event.head_commit.message, '[skip ci]') && success() && github.ref == 'refs/heads/main'}}
+    if: ${{ !startsWith(github.event.head_commit.message, '[skip ci]') && success() && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- allow GitHub Actions build job to run on pull requests

## Testing
- `./gradlew tasks --all | head -n 5` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683a677082388332bd146e66fe37492a