### PR TITLE
fix(BottomShortcutMenu): try fix BottomShortcutMenu not work on higher version

### DIFF
--- a/app/src/main/java/moe/ono/hooks/item/chat/BottomShortcutMenu.kt
+++ b/app/src/main/java/moe/ono/hooks/item/chat/BottomShortcutMenu.kt
@@ -36,7 +36,7 @@ import moe.ono.util.SyncUtils
 @SuppressLint("DiscouragedApi")
 @HookItem(
     path = "聊天与消息/快捷菜单",
-    description = "长按红包按钮调出快捷菜单，部分功能依赖此选项，推荐开启"
+    description = "长按红包或拍照按钮调出快捷菜单，部分功能依赖此选项，推荐开启"
 )
 class BottomShortcutMenu : BaseSwitchFunctionHookItem() {
     private val classNames: List<String> = mutableListOf(
@@ -52,7 +52,7 @@ class BottomShortcutMenu : BaseSwitchFunctionHookItem() {
 
             hookAfter(method) { param: MethodHookParam ->
                 val imageView = param.result as ImageView
-                if ("红包".contentEquals(imageView.contentDescription)) {
+                if ("红包".contentEquals(imageView.contentDescription) || "拍照".contentEquals(imageView.contentDescription)) {
                     imageView.setOnLongClickListener { view: View ->
                         val fixContext =
                             CommonContextWrapper.createAppCompatContext(imageView.context)


### PR DESCRIPTION
## **尝试** 修复快捷菜单因为红包快捷方式在高版本消失而无法打开的情况

通过添加 “拍照” 快捷方式作为打开快捷菜单的方式修复

由于无新版本测试环境不清楚是否正常修复（在 9135 测试通过）

由于无新版本测试环境没有增加版本检测, 目前是 “红包” “拍照” 两个方式共存