### PR TITLE
feat: manual decrypt and inject vconsole

### DIFF
--- a/app/src/main/java/moe/ono/creator/JsonViewerDialog.kt
+++ b/app/src/main/java/moe/ono/creator/JsonViewerDialog.kt
@@ -1,0 +1,113 @@
+package moe.ono.creator
+
+import android.annotation.SuppressLint
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.widget.Button
+import android.widget.RadioGroup
+import com.lxj.xpopup.XPopup
+import com.lxj.xpopup.core.BasePopupView
+import com.lxj.xpopup.core.BottomPopupView
+import com.lxj.xpopup.util.XPopupUtils
+import moe.ono.R
+import moe.ono.hooks.base.util.Toasts
+import moe.ono.ui.CommonContextWrapper
+import moe.ono.ui.view.JsonViewer
+import moe.ono.util.AppRuntimeHelper
+import moe.ono.util.analytics.ActionReporter
+import org.json.JSONObject
+
+@SuppressLint("ResourceType")
+class JsonViewerDialog(context: Context) : BottomPopupView(context) {
+    @SuppressLint("SetTextI18n", "ServiceCast")
+    override fun onCreate() {
+        super.onCreate()
+        Handler(Looper.getMainLooper()).postDelayed({
+            val jsonViewer = findViewById<JsonViewer>(R.id.rv_json)
+            val btnCopy = findViewById<Button>(R.id.btn_copy)
+            val rgType = findViewById<RadioGroup>(R.id.rg_type)
+            var copyText: String
+
+            jsonViewer.setJson(content)
+
+            copyText = jsonViewer.getJSONString()
+
+            rgType.visibility = GONE
+
+            btnCopy.setOnClickListener {
+                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                clipboard.setPrimaryClip(ClipData.newPlainText("Copied Text", copyText))
+                Toasts.info(context, "已复制")
+            }
+
+
+        }, 100)
+    }
+
+    private fun formatMsgRecord(input: String): String {
+        var indentLevel = 0
+        val indentStep = "    "
+        val result = StringBuilder()
+
+        input.forEach { char ->
+            when (char) {
+                '{' -> {
+                    result.append(char)
+                    result.append("\n")
+                    indentLevel++
+                    result.append(indentStep.repeat(indentLevel))
+                }
+                '}' -> {
+                    result.append("\n")
+                    indentLevel = if (indentLevel > 0) indentLevel - 1 else 0
+                    result.append(indentStep.repeat(indentLevel))
+                    result.append(char)
+                }
+                ',' -> {
+                    result.append(char)
+                    result.append("\n")
+                    result.append(indentStep.repeat(indentLevel))
+                }
+                else -> {
+                    result.append(char)
+                }
+            }
+        }
+        return result.toString()
+    }
+
+
+
+
+    override fun getImplLayoutId(): Int {
+        return R.layout.layout_qq_message_fetcher_result
+    }
+
+    companion object {
+        private var popupView: BasePopupView? = null
+        private var content: JSONObject? = null
+
+        fun createView(context: Context, content: JSONObject) {
+            val fixContext = CommonContextWrapper.createAppCompatContext(context)
+            val newPop = XPopup.Builder(fixContext).moveUpToKeyboard(true).isDestroyOnDismiss(true)
+            newPop.maxHeight((XPopupUtils.getScreenHeight(context) * .90f).toInt())
+            newPop.popupHeight((XPopupUtils.getScreenHeight(context) * .90f).toInt())
+            Companion.content = content
+
+
+            ActionReporter.reportVisitor(
+                AppRuntimeHelper.getAccount(),
+                "CreateView-JsonViewerDialog"
+            )
+
+            popupView = newPop.asCustom(JsonViewerDialog(fixContext))
+            popupView?.show()
+        }
+    }
+}
+
+
+

--- a/app/src/main/java/moe/ono/hooks/base/api/QQOnLoadWebView.kt
+++ b/app/src/main/java/moe/ono/hooks/base/api/QQOnLoadWebView.kt
@@ -7,6 +7,7 @@ import moe.ono.hooks._core.annotation.HookItem
 import moe.ono.hooks.clazz
 import moe.ono.hooks.item.chat.QQBubbleRedirect.Companion.injectJavaScriptLogic
 import moe.ono.hooks.item.chat.QQBubbleRedirect.Companion.injectWebViewForBubble
+import moe.ono.hooks.item.developer.InjectVConsole
 import moe.ono.util.Logger
 import moe.ono.util.SyncUtils
 import moe.ono.util.Utils
@@ -35,6 +36,12 @@ class QQOnLoadWebView : ApiHookItem() {
             Logger.d("QQOnLoadWebView -> onPageFinished")
 
             try {
+                InjectVConsole.injectJavaScriptLogic(
+                    x5WebView = it.args[0],
+                    x5WebViewClass = CacheConfig.getX5WebViewClass(),
+                    x5ValueCallbackClass = CacheConfig.getX5ValueCallbackClass()
+                )
+
                 injectJavaScriptLogic(
                     x5WebView = it.args[0],
                     itemId = CacheConfig.getItemID(),
@@ -50,6 +57,8 @@ class QQOnLoadWebView : ApiHookItem() {
         hookAfter(mLoadUrl) {
             val url = it.args[0] as String
             Logger.d("loadUrl: $url")
+
+            InjectVConsole.injectWebViewForVConsole(it.thisObject)
 
             if (url.startsWith("https://zb.vip.qq.com/mall/item-detail?appid=2&")) {
                 val webView = it.thisObject

--- a/app/src/main/java/moe/ono/hooks/dispatcher/MenuBuilderHook.kt
+++ b/app/src/main/java/moe/ono/hooks/dispatcher/MenuBuilderHook.kt
@@ -3,6 +3,7 @@ package moe.ono.hooks.dispatcher
 import de.robv.android.xposed.XC_MethodHook
 import moe.ono.hooks._base.ApiHookItem
 import moe.ono.hooks._core.annotation.HookItem
+import moe.ono.hooks.item.chat.MessageEncryptor
 import moe.ono.hooks.item.chat.StickerPanelEntry
 import moe.ono.hooks.item.developer.QQMessageFetcher
 import moe.ono.hooks.item.entertainment.ModifyTextMessage
@@ -18,7 +19,8 @@ class MenuBuilderHook : ApiHookItem() {
         QQMessageTracker(),
         QQMessageFetcher(),
         ModifyTextMessage(),
-        RespondFace()
+        RespondFace(),
+        MessageEncryptor(),
     )
 
     override fun entry(classLoader: ClassLoader) {

--- a/app/src/main/java/moe/ono/hooks/item/developer/InjectVConsole.kt
+++ b/app/src/main/java/moe/ono/hooks/item/developer/InjectVConsole.kt
@@ -1,0 +1,113 @@
+package moe.ono.hooks.item.developer
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.webkit.JavascriptInterface
+import moe.ono.config.CacheConfig
+import moe.ono.hooks._base.BaseSwitchFunctionHookItem
+import moe.ono.hooks._core.annotation.HookItem
+import moe.ono.hooks._core.factory.HookItemFactory.getItem
+import moe.ono.hooks.base.util.Toasts
+import moe.ono.util.Logger
+
+
+@SuppressLint("DiscouragedApi")
+@HookItem(path = "开发者选项/InjectVConsole", description = "对所有的网页尝试注入 VConsole\n* 重启生效")
+class InjectVConsole : BaseSwitchFunctionHookItem() {
+    @Throws(Throwable::class)
+    override fun entry(classLoader: ClassLoader) {
+    }
+
+
+
+    companion object {
+        @JvmStatic
+        fun injectWebViewForVConsole(webView: Any) {
+            try {
+                val x5WebViewClass = Class.forName("com.tencent.smtt.sdk.WebView")
+                val x5ValueCallbackClass = Class.forName("com.tencent.smtt.sdk.ValueCallback")
+
+                createX5WebViewClient(
+                    x5WebViewClass = x5WebViewClass,
+                    x5ValueCallbackClass = x5ValueCallbackClass
+                )
+
+                val addJsInterfaceMethod = webView.javaClass.getMethod(
+                    "addJavascriptInterface",
+                    Any::class.java,
+                    String::class.java
+                )
+                val context = getWebViewContext(webView)
+                addJsInterfaceMethod.invoke(webView, WebAppInterfaceForVConsole(context), "obj")
+            } catch (e: Exception) {
+                Logger.e("注入失败: ${e.stackTraceToString()}")
+            }
+        }
+        private fun createX5WebViewClient(
+            x5WebViewClass: Class<*>,
+            x5ValueCallbackClass: Class<*>
+        ) {
+            try {
+                CacheConfig.setX5WebViewClass(x5WebViewClass)
+                CacheConfig.setX5ValueCallbackClass(x5ValueCallbackClass)
+            } catch (e: Exception) {
+                Logger.e("创建 X5 WebViewClient 失败: ${e.stackTraceToString()}")
+                throw RuntimeException("无法创建 X5 WebViewClient", e)
+            }
+        }
+        fun injectJavaScriptLogic(
+            x5WebView: Any?,
+            x5WebViewClass: Class<*>,
+            x5ValueCallbackClass: Class<*>
+        ) {
+            if (!getItem(InjectVConsole::class.java).isEnabled) return
+            try {
+                val jsCode = """
+            (function injectVConsole() {
+  if (window.VConsole) return;
+  const s = document.createElement('script');
+  s.src = 'https://unpkg.com/vconsole@latest/dist/vconsole.min.js';
+  s.onload = () => {
+    try { window.vConsole = new VConsole(); console.log('vConsole injected') }
+    catch (e) { console.error('vConsole init failed', e) }
+  };
+  s.onerror = () => obj.toast("注入失败");
+  document.head.appendChild(s);
+})();
+        """.trimIndent()
+
+                val evaluateMethod = x5WebViewClass.getMethod(
+                    "evaluateJavascript",
+                    String::class.java,
+                    x5ValueCallbackClass
+                )
+
+                evaluateMethod.invoke(x5WebView, jsCode, null)
+
+            } catch (e: Exception) {
+                Logger.e("JS注入失败: ${e.stackTraceToString()}")
+            }
+        }
+
+
+        private fun getWebViewContext(webView: Any): Context {
+            return try {
+                webView.javaClass.getMethod("getContext").invoke(webView) as Context
+            } catch (e: NoSuchMethodException) {
+                val field = webView.javaClass.getDeclaredField("mContext").apply {
+                    isAccessible = true
+                }
+                field.get(webView) as Context
+            } catch (e: Exception) {
+                throw RuntimeException("无法获取WebView Context", e)
+            }
+        }
+
+        class WebAppInterfaceForVConsole(private val context: Context) {
+            @JavascriptInterface
+            fun toast(text: String) {
+                Toasts.error(context, text)
+            }
+        }
+    }
+}

--- a/app/src/main/java/moe/ono/hooks/item/developer/QQMessageFetcher.kt
+++ b/app/src/main/java/moe/ono/hooks/item/developer/QQMessageFetcher.kt
@@ -80,9 +80,11 @@ class QQMessageFetcher : BaseSwitchFunctionHookItem(), OnMenuBuilder {
         param.result = listOf(item) + param.result as List<*>
     }
 
-    private fun pullGroupMsg(msgRecord: MsgRecord){
-        val seq = msgRecord.msgSeq
-        sendPacket("MessageSvc.PbGetGroupMsg", """{"1": ${msgRecord.peerUid}, "2": ${seq}, "3": ${seq}, "6": 0}""")
+    companion object {
+        fun pullGroupMsg(msgRecord: MsgRecord){
+            val seq = msgRecord.msgSeq
+            sendPacket("MessageSvc.PbGetGroupMsg", """{"1": ${msgRecord.peerUid}, "2": ${seq}, "3": ${seq}, "6": 0}""")
+        }
     }
 
     private fun pullC2CMsg(msgRecord: MsgRecord){

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -9,4 +9,5 @@
     <item name="ivTitleName" type="id"/>
     <item name="item_modify_text_message" type="id" />
     <item name="item_respond_face" type="id" />
+    <item name="item_message_encryptor" type="id" />
 </resources>


### PR DESCRIPTION
## Feature

1. [feat(MessageEncryptor): manual decrypt](https://github.com/KyuharuTE/ono/commit/f0e5754e150c1335ea4f171cddfafb4dfeb892fb)
2. [feat: add inject vconsole](https://github.com/KyuharuTE/ono/commit/fd9abdb43f14833835b5b28149320918ddc2d150)

## 补充一下忘记说的 :)

1. 手动解密如果是文本消息则修改消息，如果是其它的则显示 PB

## 已知问题

1. 解密按钮必须在开始加密抄送时出现
2. JsonViewer 弹窗标题显示原始消息

已知问题明天修复