### PR TITLE
fix: fix BottomShortcutMenu, JsonViewerDialog and ManualDecrypt

### DIFF
--- a/app/src/main/java/moe/ono/creator/JsonViewerDialog.kt
+++ b/app/src/main/java/moe/ono/creator/JsonViewerDialog.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.Looper
 import android.widget.Button
 import android.widget.RadioGroup
+import android.widget.TextView
 import com.lxj.xpopup.XPopup
 import com.lxj.xpopup.core.BasePopupView
 import com.lxj.xpopup.core.BottomPopupView
@@ -29,7 +30,10 @@ class JsonViewerDialog(context: Context) : BottomPopupView(context) {
             val jsonViewer = findViewById<JsonViewer>(R.id.rv_json)
             val btnCopy = findViewById<Button>(R.id.btn_copy)
             val rgType = findViewById<RadioGroup>(R.id.rg_type)
+            val title = findViewById<TextView>(R.id.title)
             var copyText: String
+
+            title.text = "Json Viewer"
 
             jsonViewer.setJson(content)
 
@@ -46,40 +50,6 @@ class JsonViewerDialog(context: Context) : BottomPopupView(context) {
 
         }, 100)
     }
-
-    private fun formatMsgRecord(input: String): String {
-        var indentLevel = 0
-        val indentStep = "    "
-        val result = StringBuilder()
-
-        input.forEach { char ->
-            when (char) {
-                '{' -> {
-                    result.append(char)
-                    result.append("\n")
-                    indentLevel++
-                    result.append(indentStep.repeat(indentLevel))
-                }
-                '}' -> {
-                    result.append("\n")
-                    indentLevel = if (indentLevel > 0) indentLevel - 1 else 0
-                    result.append(indentStep.repeat(indentLevel))
-                    result.append(char)
-                }
-                ',' -> {
-                    result.append(char)
-                    result.append("\n")
-                    result.append(indentStep.repeat(indentLevel))
-                }
-                else -> {
-                    result.append(char)
-                }
-            }
-        }
-        return result.toString()
-    }
-
-
 
 
     override fun getImplLayoutId(): Int {

--- a/app/src/main/java/moe/ono/creator/center/ClickableFunctionDialog.kt
+++ b/app/src/main/java/moe/ono/creator/center/ClickableFunctionDialog.kt
@@ -507,6 +507,11 @@ object ClickableFunctionDialog {
         checkBox.isChecked = item.isEnabled
         root.addView(checkBox)
 
+        val manualDecryptCheckBox = MaterialCheckBox(context)
+        manualDecryptCheckBox.text = "启用手动解密"
+        manualDecryptCheckBox.isChecked = ConfigManager.dGetBoolean(Constants.PrekCfgXXX + "manualDecrypt")
+        root.addView(manualDecryptCheckBox)
+
         val inputMarginTop = (8 * context.resources.displayMetrics.density).toInt()
 
         val tilKey = TextInputLayout(context)
@@ -567,6 +572,10 @@ object ClickableFunctionDialog {
                     item.startLoad()
                 } else {
                 }
+            }
+
+            manualDecryptCheckBox.setOnCheckedChangeListener { _, isChecked ->
+                ConfigManager.dPutBoolean(Constants.PrekCfgXXX + "manualDecrypt", isChecked)
             }
 
             val keyWatcher: TextWatcher = object : TextWatcher {

--- a/app/src/main/java/moe/ono/hooks/item/chat/BottomShortcutMenu.kt
+++ b/app/src/main/java/moe/ono/hooks/item/chat/BottomShortcutMenu.kt
@@ -58,23 +58,36 @@ class BottomShortcutMenu : BaseSwitchFunctionHookItem() {
                             if (parent is ViewGroup) {
                                 Logger.d(parent::class.java.name)
 
-                                val onoImageView = ImageView(parent.context)
-                                onoImageView.setImageResource(R.drawable.ic_ouo)
-
-                                val layoutParams = LinearLayout.LayoutParams(0, (28.0f * parent.resources.displayMetrics.density + 0.5f).toInt())
-                                layoutParams.weight = 1.0f
-                                layoutParams.gravity = 16
-
-                                onoImageView.layoutParams = layoutParams
-
-                                onoImageView.setOnClickListener { view ->
-                                    val fixContext =
-                                        CommonContextWrapper.createAppCompatContext(imageView.context)
-                                    popMenu(fixContext, view)
-                                    true
+                                fun foundONO(view: ViewGroup) : Boolean {
+                                    for (i in 0 until view.childCount) {
+                                        val child = view.getChildAt(i)
+                                        if (child.contentDescription == "ONO") {
+                                            return true
+                                        }
+                                    }
+                                    return false
                                 }
 
-                                parent.addView(onoImageView, 4)
+                                if (!foundONO(parent)) {
+                                    val onoImageView = ImageView(parent.context)
+                                    onoImageView.setImageResource(R.drawable.ic_ouo)
+                                    onoImageView.contentDescription = "ONO"
+
+                                    val layoutParams = LinearLayout.LayoutParams(0, (28.0f * parent.resources.displayMetrics.density + 0.5f).toInt())
+                                    layoutParams.weight = 1.0f
+                                    layoutParams.gravity = 16
+
+                                    onoImageView.layoutParams = layoutParams
+
+                                    onoImageView.setOnClickListener { view ->
+                                        val fixContext =
+                                            CommonContextWrapper.createAppCompatContext(imageView.context)
+                                        popMenu(fixContext, view)
+                                        true
+                                    }
+
+                                    parent.addView(onoImageView, 4)
+                                }
                             }
                         }
 

--- a/app/src/main/java/moe/ono/hooks/item/chat/MessageEncryptor.kt
+++ b/app/src/main/java/moe/ono/hooks/item/chat/MessageEncryptor.kt
@@ -17,12 +17,12 @@ import moe.ono.bridge.ntapi.ChatTypeConstants.GROUP
 import moe.ono.bridge.ntapi.MsgServiceHelper
 import moe.ono.config.ConfigManager
 import moe.ono.config.DailySaying
+import moe.ono.constants.Constants
 import moe.ono.ext.getUnknownObject
 import moe.ono.ext.getUnknownObjects
 import moe.ono.ext.toInnerValuesString
 import moe.ono.hooks._base.BaseClickableFunctionHookItem
 import moe.ono.hooks._core.annotation.HookItem
-import moe.ono.hooks._core.factory.HookItemFactory.getItem
 import moe.ono.hooks.base.util.Toasts
 import moe.ono.hooks.dispatcher.OnMenuBuilder
 import moe.ono.hooks.item.developer.QQHookCodec
@@ -42,7 +42,7 @@ import moe.ono.util.Session
 import moe.ono.util.SyncUtils
 
 @SuppressLint("DiscouragedApi")
-@HookItem(path = "聊天与消息/群聊加密消息", description = "发送的消息将加密抄送，仅针对群聊\n* 长按文本消息可手动解密\n* 手动解密功能依赖 娱乐功能/修改文本消息\n* 开启需重启\n* 禁止用于非法用途，违者后果自负\n* 需开启 '开发者选项/注入 CodecWarpper'")
+@HookItem(path = "聊天与消息/群聊加密消息", description = "发送的消息将加密抄送，仅针对群聊\n* 长按文本消息可手动解密(需开启手动解密)\n* 手动解密功能依赖 娱乐功能/修改文本消息\n* 开启需重启\n* 禁止用于非法用途，违者后果自负\n* 需开启 '开发者选项/注入 CodecWarpper'")
 class MessageEncryptor : BaseClickableFunctionHookItem(), OnMenuBuilder {
     companion object {
         var decryptMsg = false
@@ -199,7 +199,7 @@ class MessageEncryptor : BaseClickableFunctionHookItem(), OnMenuBuilder {
     )
 
     override fun onGetMenu(aioMsgItem: Any, targetType: String, param: XC_MethodHook.MethodHookParam) {
-        if (!getItem(this.javaClass).isEnabled) {
+        if (!ConfigManager.dGetBoolean(Constants.PrekCfgXXX + "manualDecrypt")) {
             return
         }
 

--- a/app/src/main/res/layout/layout_qq_message_fetcher_result.xml
+++ b/app/src/main/res/layout/layout_qq_message_fetcher_result.xml
@@ -31,6 +31,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:id="@+id/title"
                     android:layout_gravity="center_horizontal"
                     android:text="原始消息"
                     android:textSize="19sp"


### PR DESCRIPTION
## Fixes

1. [fix(BottomShortcutMenu): fix BottomShortcutMenu not work on higher version](https://github.com/KyuharuTE/ono/commit/0fa4ed704dafb843a10cf7eeea61449db24754d7)
2. [fix(JsonViewerDialog): change title to "Json Viewer"](https://github.com/KyuharuTE/ono/commit/428e5bd9666ef4c6ab2ff1929c8d7f2e7528819f)
3. [fix(MessageEncrypt): manual decrypt icon can set whether always display](https://github.com/cwuom/ono/pull/16/commits/3bb4545279be3034945939afdd24ecd0accc2a25)

---

BottomShortcutMenu 修复方式: 添加 ONO 图标作为新的入口

MessageEncrypt 修复方式: 增加手动解密开关

在 9.2.23 通过测试

## THANKS

感谢 **[秋行](https://t.me/xiaoqiuxing)** 提供高版本测试环境