### PR TITLE
fix(#22): fix ono config deleted when qq clear cache, fixes #22

### DIFF
--- a/app/src/main/java/moe/ono/core/NativeCoreBridge.java
+++ b/app/src/main/java/moe/ono/core/NativeCoreBridge.java
@@ -1,5 +1,7 @@
 package moe.ono.core;
 
+import static moe.ono.util.io.FileUtils.copyFile;
+
 import android.content.Context;
 
 import androidx.annotation.NonNull;
@@ -7,9 +9,11 @@ import androidx.annotation.NonNull;
 import com.tencent.mmkv.MMKV;
 
 import java.io.File;
+import java.io.IOException;
 
-import moe.ono.startup.StartupInfo;
+import moe.ono.util.FileUtils;
 import moe.ono.util.HostInfo;
+import moe.ono.util.Logger;
 
 
 public class NativeCoreBridge {
@@ -44,7 +48,11 @@ public class NativeCoreBridge {
         if (sPrimaryNativeLibraryInitialized) {
             return;
         }
-        File filesDir = ctx.getFilesDir();
+        File filesDir = ctx.getExternalMediaDirs()[0];
+        if (filesDir == null) {
+            filesDir = ctx.getFilesDir();
+        }
+
         File mmkvDir = new File(filesDir, "ono_mmkv");
         if (!mmkvDir.exists()) {
             mmkvDir.mkdirs();
@@ -53,6 +61,26 @@ public class NativeCoreBridge {
         File cacheDir = new File(mmkvDir, ".tmp");
         if (!cacheDir.exists()) {
             cacheDir.mkdir();
+        }
+        File oldDir = new File(ctx.getFilesDir(), "ono_mmkv");
+        if (oldDir.exists() && oldDir.isDirectory()) {
+            File[] files = oldDir.listFiles();
+            if (files == null) return;
+
+            for (File src : files) {
+                if (!src.isFile()) continue;
+                File dest = new File(mmkvDir, src.getName());
+                if (!dest.exists()) {
+                    try {
+                        copyFile(src, dest);
+                        Logger.i("Copy config file: " + src.getName());
+                    } catch (IOException e) {
+                        Logger.e(e);
+                    }
+                }
+            }
+
+            FileUtils.deleteFile(oldDir);
         }
         MMKV.initialize(ctx, mmkvDir.getAbsolutePath());
         MMKV.mmkvWithID("global_config", MMKV.MULTI_PROCESS_MODE);


### PR DESCRIPTION
## Fix

1. [fix(#22): fix ono config deleted when qq clear cache, fixes #22](https://github.com/cwuom/ono/commit/ec27e2674a40bb773fd53c23d8ddcc97338c67b8)

## 补充说明

1. 将 mmkv 文件移至 media 目录, 并自动检测是否存在原配置文件及迁移

fixes #22 